### PR TITLE
Fix mstats on core dumps and Python 2

### DIFF
--- a/libheap/ptmalloc/ptmalloc.py
+++ b/libheap/ptmalloc/ptmalloc.py
@@ -96,11 +96,21 @@ class ptmalloc:
 
     def mutex_lock(self, ar_ptr):
         ar_ptr.mutex = 1
-        self.dbg.write_memory(ar_ptr.address, struct.pack("<I", ar_ptr.mutex))
+        try:
+            self.dbg.write_memory(ar_ptr.address,
+                                  struct.pack("<I", ar_ptr.mutex))
+        except:
+            # write_memory does not work on core dumps, but we also don't need
+            # to lock the mutex there
+            pass
 
     def mutex_unlock(self, ar_ptr):
         ar_ptr.mutex = 0
-        self.dbg.write_memory(ar_ptr.address, struct.pack("<I", ar_ptr.mutex))
+        try:
+            self.dbg.write_memory(ar_ptr.address,
+                                  struct.pack("<I", ar_ptr.mutex))
+        except:
+            pass
 
     def prev_inuse(self, p):
         "extract inuse bit of previous chunk"

--- a/libheap/ptmalloc/ptmalloc.py
+++ b/libheap/ptmalloc/ptmalloc.py
@@ -190,8 +190,12 @@ class ptmalloc:
             offsetof_fd = 0x10
             cast_type = 'unsigned long'
 
-        cmd_str = "&((struct malloc_state *) {:#x}).bins[{}]".format(
-                  int(m.address), int((i - 1) * 2))
+        # This works on both Python 2 and 3 while casting m.address to int (in
+        # order to format it with the '{:x}'.format) only works on Python 3
+        addr = '%#x' % m.address
+
+        cmd_str = "&((struct malloc_state *) {}).bins[{}]".format(
+                  addr, int((i - 1) * 2))
         return int(parse_and_eval(cmd_str).cast(lookup_type(cast_type))
                    - offsetof_fd)
 


### PR DESCRIPTION
The recent refactoring seems to have broken mstats for core dumps and also for Python 2.  These patches fix those two problems.