### PR TITLE
Fix gdb.Value cast for gdb 7.7

### DIFF
--- a/libheap/pydbg/pygdbpython.py
+++ b/libheap/pydbg/pygdbpython.py
@@ -39,7 +39,7 @@ class pygdbpython:
         except gdb.error:
             # python2 error: Cannot convert value to int.
             # value.cast(gdb.lookup_type("unsigned long"))
-            ret = int(str(value), 16)
+            ret = int(str(value).split(' ')[0], 16)
 
         return ret
 


### PR DESCRIPTION
At least on some gdb versions, such as 7.7.1 which is used in Debian
stable, the string representation of the value looks like
"0x7f8c87ba1620 <main_arena>", so we should only attempt to convert the
address portion.